### PR TITLE
Clear the cache before continuing with the upgrade.

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,7 +11,7 @@ services:
   # Module upgrader and version checker
   cmfcmf_media_module.upgrade.module_upgrader:
     class: Cmfcmf\Module\MediaModule\Upgrade\ModuleUpgrader
-    arguments: [@translator, %kernel.cache_dir%, %kernel.root_dir%]
+    arguments: [@translator, @zikula.cache_clearer, %kernel.cache_dir%, %kernel.root_dir%]
 
   cmfcmf_media_module.upgrade.version_checker:
     class: Cmfcmf\Module\MediaModule\Upgrade\VersionChecker

--- a/Upgrade/ModuleUpgrader.php
+++ b/Upgrade/ModuleUpgrader.php
@@ -4,6 +4,7 @@ namespace Cmfcmf\Module\MediaModule\Upgrade;
 
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Translation\TranslatorInterface;
+use Zikula\Bundle\CoreBundle\CacheClearer;
 
 class ModuleUpgrader
 {
@@ -32,17 +33,23 @@ class ModuleUpgrader
      */
     private $domain;
 
-    public function __construct(TranslatorInterface $translator, $kernelCacheDir, $kernelRootDir)
+    /**
+     * @var CacheClearer
+     */
+    private $cacheClearer;
+
+    public function __construct(TranslatorInterface $translator, CacheClearer $cacheClearer, $kernelCacheDir, $kernelRootDir)
     {
+        $this->domain = \ZLanguage::getModuleDomain('CmfcmfMediaModule');
+        $this->translator = $translator;
+        $this->cacheClearer = $cacheClearer;
+
         $this->fs = new Filesystem();
         $this->cacheFile = $kernelCacheDir . "/CmfcmfMediaModule.zip";
 
         $zikulaDir = realpath($kernelRootDir . '/..');
         $this->moduleDir = $this->fs->makePathRelative(realpath(__DIR__ . '/..'), $zikulaDir);
         $this->moduleDir = rtrim($this->moduleDir, '/\\');
-
-        $this->domain = \ZLanguage::getModuleDomain('CmfcmfMediaModule');
-        $this->translator = $translator;
     }
 
     public function checkRequirements()
@@ -91,6 +98,8 @@ class ModuleUpgrader
         $zip->close();
 
         $this->fs->remove($this->cacheFile);
+
+        $this->cacheClearer->clear('symfony');
 
         return true;
     }


### PR DESCRIPTION
In preparation for version 1.1.0.